### PR TITLE
Bug/vue/template property alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ module.exports = {
 		// Vue: configure extended rules
 		'vue/component-name-in-template-casing' : [ 'error', 'kebab-case' ],
 		'vue/html-indent'                       : [ 'error', 'tab' ],
+		'vue/no-multi-spaces'                   : [ 'error', { "ignoreProperties" : true } ], // allow aligning of object properties
 
 		// Vue: enable extra rules
 		'vue/no-v-html'           : 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadmunk/eslint-config-roadmunk",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "This holds the base Roadmunk shop standard ESLint configuration file.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Allow alignment of object properties in vue templates

see https://vuejs.github.io/eslint-plugin-vue/rules/no-multi-spaces.html#ignoreproperties-true