### PR TITLE
DB-11 use 'warn' not 'warning'

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = {
 		'@roadmunk/roadmunk-custom/order-require'                   : 'error',
 		'@roadmunk/roadmunk-custom/assert-length'                   : 'error',
 		'@roadmunk/roadmunk-custom/log-message-length'              : 'error',
-		'@roadmunk/roadmunk-custom/no-require-views'                : 'warning',
+		'@roadmunk/roadmunk-custom/no-require-views'                : 'warn',
 
 		// Vue: disable some extended rules
 		'vue/max-attributes-per-line'                : 'off', // doesn't work with our pattern of allowing `class` and `id` static attrs on first line
@@ -139,6 +139,6 @@ module.exports = {
 		// Vue: enable extra rules
 		'vue/no-v-html'           : 'error',
 		'vue/order-in-components' : 'error',
-		'vue/this-in-template'    : 'warning',
+		'vue/this-in-template'    : 'warn',
 	},
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadmunk/eslint-config-roadmunk",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "This holds the base Roadmunk shop standard ESLint configuration file.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
[DB-11](https://roadmunk.atlassian.net/browse/DB-11)

I found this issue when testing the eslint with our code. We used "warning" somewhere else in the `index.js` which according to eslint should be "warn".